### PR TITLE
feat(lerna): add support for a "mono-run" command

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -41,6 +41,17 @@
       "windows": {
         "program": "${workspaceFolder}/node_modules/jest/bin/jest",
       }
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Web Tests",
+      "cwd": "${workspaceFolder}/packages/web/",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["--runInBand", "--coverage", "false"],
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      }
     }
   ]
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,6 +2,7 @@ import * as program from 'commander';
 import dev from './dev';
 import installDeps from './install-deps';
 import listBranches from './list-branches';
+import monoRun from './mono-run';
 
 program
   .command('dev [branch]')
@@ -14,7 +15,7 @@ program
 program
   .command('list-branches')
   .description('Lists the git branches most recently committed to.')
-  .option('-n', '--num-branches', 5)
+  .option('-n, --num-branches', 'The number of branches to list', 5)
   .action(({ numBranches }) => {
     listBranches(numBranches);
   });
@@ -23,12 +24,26 @@ program
   .command('install-deps')
   .description('Optionally clean and then install dependencies.')
   .option(
-    '-c',
-    '--clean',
+    '-c, --clean',
     'Clean previously installed dependencies before installing.',
   )
   .action(({ clean }) => {
     installDeps(!!clean);
+  });
+
+program
+  .command('mono-run [command]')
+  .description('Run a NPM script in a monorepo using lerna')
+  .option(
+    '-t, --target [package-name]',
+    'The name of a package to which the scope should be limited.',
+  )
+  .option(
+    '-p, --package-location [package-location]',
+    'The location of a package to which the scope should be limited.',
+  )
+  .action((command, { target, packageLocation }) => {
+    monoRun(command, target, packageLocation);
   });
 
 program.parse(process.argv);

--- a/packages/cli/src/list-branches.ts
+++ b/packages/cli/src/list-branches.ts
@@ -4,6 +4,5 @@ const cwd = process.cwd();
 
 export default async function(numBranches: number) {
   const branches = await getRecentBranches(cwd, numBranches);
-  // tslint:disable-next-line:no-console
   branches.forEach(b => console.log(b));
 }

--- a/packages/cli/src/mono-run.ts
+++ b/packages/cli/src/mono-run.ts
@@ -1,0 +1,19 @@
+import { runScriptInMonorepo } from '@merl/web';
+
+const cwd = process.cwd();
+
+export default async function(
+  command: string,
+  target?: string,
+  packageLocation?: string,
+) {
+  const runProcess = await runScriptInMonorepo(
+    cwd,
+    command,
+    target,
+    packageLocation,
+  );
+
+  runProcess.stdout.pipe(process.stdout);
+  runProcess.stderr.pipe(process.stderr);
+}

--- a/packages/cli/tslint.json
+++ b/packages/cli/tslint.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../../tslint.base.json"
+  "extends": "../../tslint.base.json",
+  "rules": {
+    "no-console": false
+  }
 }

--- a/packages/util/src/exec.spec.ts
+++ b/packages/util/src/exec.spec.ts
@@ -1,7 +1,7 @@
 jest.mock('child_process');
 
 import * as child_process from 'child_process';
-import { exec } from './exec';
+import { exec, spawn } from './exec';
 
 test('executes the command in a child process', async () => {
   let handler: any;
@@ -40,4 +40,17 @@ test('handles a non-zero exit code from the child process', done => {
   } else {
     handler('git error');
   }
+});
+
+test('spawn will return immediately with output streams', async () => {
+  (child_process.spawn as any).mockImplementation(() => undefined);
+  spawn('git status', 'cwd');
+  expect(child_process.spawn).toHaveBeenCalledWith('git status', [], {
+    cwd: 'cwd',
+    env: {
+      FORCE_COLOR: 'true',
+    },
+    shell: true,
+    windowsHide: true,
+  });
 });

--- a/packages/util/src/exec.ts
+++ b/packages/util/src/exec.ts
@@ -1,4 +1,5 @@
 import * as child_process from 'child_process';
+import { ChildProcess } from 'child_process';
 
 /**
  * Executes the given command in the given working directory
@@ -24,5 +25,20 @@ export function exec(command: string, cwd: string): Promise<string> {
 
       resolve(stdout);
     });
+  });
+}
+
+/**
+ * Like `exec` except returns the `ChildProcess` immediately so
+ * consumers can pipe the output.
+ */
+export function spawn(command: string, cwd: string): ChildProcess {
+  return child_process.spawn(command, [], {
+    cwd,
+    env: {
+      FORCE_COLOR: 'true',
+    },
+    shell: true,
+    windowsHide: true,
   });
 }

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,2 +1,3 @@
 export * from './bower';
 export * from './npm';
+export * from './lerna';

--- a/packages/web/src/lerna.spec.ts
+++ b/packages/web/src/lerna.spec.ts
@@ -1,0 +1,60 @@
+jest.mock('fs', () => require('memfs').fs);
+jest.mock('@merl/util');
+
+import { spawn } from '@merl/util';
+import * as memfs from 'memfs';
+import { runScriptInMonorepo } from './lerna';
+
+beforeEach(() => {
+  memfs.vol.reset();
+});
+
+test('build package with npm', async () => {
+  await runScriptInMonorepo('cwd', 'build', 'my-package');
+  expect(spawn).toHaveBeenCalledTimes(1);
+  expect(spawn).toHaveBeenCalledWith(
+    `npx run lerna run --stream build --scope my-package --include-filtered-dependencies`,
+    'cwd',
+  );
+
+  await runScriptInMonorepo('cwd', 'build-it', 'my-package');
+  expect(spawn).toHaveBeenCalledTimes(2);
+  expect(spawn).toHaveBeenCalledWith(
+    `npx run lerna run --stream build-it --scope my-package --include-filtered-dependencies`,
+    'cwd',
+  );
+});
+
+test('build package with yarn', async () => {
+  memfs.vol.fromJSON({
+    '/proj/test/yarn.lock': 'lockfile',
+  });
+
+  await runScriptInMonorepo('/proj/test/', 'build', 'my-package');
+  expect(spawn).toHaveBeenCalledTimes(1);
+  expect(spawn).toHaveBeenCalledWith(
+    `yarn run lerna run --stream build --scope my-package --include-filtered-dependencies`,
+    '/proj/test/',
+  );
+});
+
+test('build package with path', async () => {
+  memfs.vol.fromJSON({
+    '/proj/test/package.json': `{
+      "name": "my-test-package"
+    }`,
+  });
+
+  await runScriptInMonorepo('/', 'build', undefined, './proj/test/');
+  expect(spawn).toHaveBeenCalledTimes(1);
+  expect(spawn).toHaveBeenCalledWith(
+    `npx run lerna run --stream build --scope my-test-package --include-filtered-dependencies`,
+    '/',
+  );
+});
+
+test('run script across whole repo', async () => {
+  await runScriptInMonorepo('cwd', 'build');
+  expect(spawn).toHaveBeenCalledTimes(1);
+  expect(spawn).toHaveBeenCalledWith(`npx run lerna run --stream build`, 'cwd');
+});

--- a/packages/web/src/lerna.ts
+++ b/packages/web/src/lerna.ts
@@ -1,0 +1,53 @@
+import { spawn } from '@merl/util';
+import { ChildProcess } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as util from 'util';
+import { projectUsesYarn } from './npm';
+
+const readFile = util.promisify(fs.readFile);
+
+/**
+ * Run the given NPM script in the monorepo that is the current working directory.
+ *
+ * @param cwd the current working directory (should be a lerna-managed monorepo)
+ * @param cmd the name of the NPM script to run in each package
+ * @param packageName the name of the NPM package in the monorepo to which the command should be scoped
+ */
+export async function runScriptInMonorepo(
+  cwd: string,
+  cmd: string,
+  packageName?: string,
+  packageLocation?: string,
+): Promise<ChildProcess> {
+  let pkgManager = 'npx';
+  if (await projectUsesYarn(cwd)) {
+    pkgManager = 'yarn';
+  }
+
+  if (packageLocation) {
+    packageName = await getPackageNameFromPath(cwd, packageLocation);
+  }
+
+  let scopeCommand = '';
+  if (packageName) {
+    scopeCommand = `--scope ${packageName} --include-filtered-dependencies`;
+  }
+
+  return spawn(
+    `${pkgManager} run lerna run --stream ${cmd} ${scopeCommand}`.trim(),
+    cwd,
+  );
+}
+
+async function getPackageNameFromPath(
+  cwd: string,
+  packageLocation: string,
+): Promise<string> {
+  const absPath = path.join(
+    path.resolve(cwd, packageLocation),
+    '/package.json',
+  );
+  const pkg = JSON.parse(await readFile(absPath, { encoding: 'utf8' }));
+  return pkg.name;
+}

--- a/packages/web/src/npm.spec.ts
+++ b/packages/web/src/npm.spec.ts
@@ -3,7 +3,7 @@ jest.mock('@merl/util');
 
 import { exec } from '@merl/util';
 import * as memfs from 'memfs';
-import { npmInstall } from './npm';
+import { npmInstall, projectUsesYarn } from './npm';
 
 afterEach(() => {
   memfs.vol.reset();
@@ -130,5 +130,18 @@ Object {
       'yarn lerna bootstrap',
       '/proj/test/',
     );
+  });
+
+  test('choose between yarn and npm', async () => {
+    memfs.vol.fromJSON({
+      '/proj/test/yarn.lock': 'lockfile',
+    });
+    await expect(projectUsesYarn('/proj/test/')).resolves.toEqual(true);
+
+    memfs.vol.reset();
+    memfs.vol.fromJSON({
+      '/proj/test/readme.md': 'readme',
+    });
+    await expect(projectUsesYarn('/proj/test/')).resolves.toEqual(false);
   });
 });

--- a/packages/web/src/npm.ts
+++ b/packages/web/src/npm.ts
@@ -20,7 +20,7 @@ export async function npmInstall(cwd: string, clean: boolean = false) {
   }
 
   const useLerna = await checkForFile('lerna.json', cwd);
-  const useYarn = await checkForFile('yarn.lock', cwd);
+  const useYarn = await projectUsesYarn(cwd);
   const hasPackageJson = await checkForFile('package.json', cwd);
 
   if (!hasPackageJson) {
@@ -32,6 +32,10 @@ export async function npmInstall(cwd: string, clean: boolean = false) {
   if (useLerna) {
     await runLernaBootstrap(useYarn, cwd);
   }
+}
+
+export async function projectUsesYarn(cwd: string): Promise<boolean> {
+  return await checkForFile('yarn.lock', cwd);
 }
 
 async function runNpmInstall(useYarn: boolean, cwd: string) {


### PR DESCRIPTION
Add a "mono-run" command that will make it easy to run
an npm script either across the whole repo or targetted
at a specific package.